### PR TITLE
Wrap paragraphs at 80 characters

### DIFF
--- a/draft-dcook-ppm-dap-interop-test-design.md
+++ b/draft-dcook-ppm-dap-interop-test-design.md
@@ -52,16 +52,40 @@ informative:
 
 --- abstract
 
-This document defines a common test interface for implementations of the Distributed Aggregation Protocol for Privacy Preserving Measurement (DAP-PPM) and describes how this test interface can be used to perform interoperation testing between the implementations. Tests are orchestrated with containers, and new test-only APIs are introduced to provision DAP-PPM tasks and initiate processing.
+This document defines a common test interface for implementations of the
+Distributed Aggregation Protocol for Privacy Preserving Measurement (DAP-PPM)
+and describes how this test interface can be used to perform interoperation
+testing between the implementations. Tests are orchestrated with containers, and
+new test-only APIs are introduced to provision DAP-PPM tasks and initiate
+processing.
 
 
 --- middle
 
 # Introduction
 
-This document defines a common test interface for implementations of the Distributed Aggregation Protocol for Privacy Preserving Measurement [DAP-PPM]. This test interface facilitates interoperation tests between different participating DAP-PPM implementations. As DAP-PPM has four distinct protocol roles, (client, leader aggregator, helper aggregator, and collector) manual interoperation testing between all combinations of even a small number of DAP-PPM implementations could be taxing. The goal of this document's common test interface is to enable automation of these interoperation tests, so that different participating implementations can be exchanged for each other, and the same test suite can be re-run on different combinations of implementations. Simplifying interoperation testing will aid in identifying errors in implementations, identifying ambiguities in the protocol specification, and reducing regressions in implementations.
+This document defines a common test interface for implementations of the
+Distributed Aggregation Protocol for Privacy Preserving Measurement [DAP-PPM].
+This test interface facilitates interoperation tests between different
+participating DAP-PPM implementations. As DAP-PPM has four distinct protocol
+roles, (client, leader aggregator, helper aggregator, and collector) manual
+interoperation testing between all combinations of even a small number of
+DAP-PPM implementations could be taxing. The goal of this document's common test
+interface is to enable automation of these interoperation tests, so that
+different participating implementations can be exchanged for each other, and the
+same test suite can be re-run on different combinations of implementations.
+Simplifying interoperation testing will aid in identifying errors in
+implementations, identifying ambiguities in the protocol specification, and
+reducing regressions in implementations.
 
-Taking inspiration from QuicInteropRunner [SI2020], each participating implementation provides one or more container images adhering to a common interface. A test runner will start one container for each protocol participant, configure networking between the containers, and send various HTTP API requests. As part of this common testing interface, the HTTP servers in the containers will support some new test-only HTTP APIs, which will allow the test runner to provision shared task parameters and secrets, as well as trigger the start of different sub-protocols.
+Taking inspiration from QuicInteropRunner [SI2020], each participating
+implementation provides one or more container images adhering to a common
+interface. A test runner will start one container for each protocol participant,
+configure networking between the containers, and send various HTTP API requests.
+As part of this common testing interface, the HTTP servers in the containers
+will support some new test-only HTTP APIs, which will allow the test runner to
+provision shared task parameters and secrets, as well as trigger the start of
+different sub-protocols.
 
 
 # Conventions and Definitions
@@ -71,27 +95,61 @@ Taking inspiration from QuicInteropRunner [SI2020], each participating implement
 
 # Container Interface
 
-Each participating DAP implementation may provide one or more container images, one for each protocol role it implements. (client, leader, helper, and collector) A list of available container images will be maintained for each role. Implementations may want to submit a single aggregator image in both the leader list and helper list. The test runner will fetch each container using the given repository, image name, and tag.
+Each participating DAP implementation may provide one or more container images,
+one for each protocol role it implements. (client, leader, helper, and
+collector) A list of available container images will be maintained for each
+role. Implementations may want to submit a single aggregator image in both the
+leader list and helper list. The test runner will fetch each container using the
+given repository, image name, and tag.
 
-When the container’s entry point executable is run, it SHALL start up an HTTP server listening on port 8080. In all cases, the container will serve the endpoints described in {{test-api}} (particularly, the subsection appropriate to its protocol role). In the case of a helper or leader container, it SHALL also serve the endpoints specified by [DAP-PPM] on a port (which MAY be the same port 8080 as used to serve the interoperation test API) at some relative path. The container should run indefinitely, and the test runner will terminate the container on completion of the test case. (While DAP-PPM requires HTTPS connections, only using HTTP between containers simplifies test setup. Putting TLS client/server interop out-of-scope for these tests is acceptable, as it’s not of interest.)
+When the container’s entry point executable is run, it SHALL start up an HTTP
+server listening on port 8080. In all cases, the container will serve the
+endpoints described in {{test-api}} (particularly, the subsection appropriate to
+its protocol role). In the case of a helper or leader container, it SHALL also
+serve the endpoints specified by [DAP-PPM] on a port (which MAY be the same port
+8080 as used to serve the interoperation test API) at some relative path. The
+container should run indefinitely, and the test runner will terminate the
+container on completion of the test case. (While DAP-PPM requires HTTPS
+connections, only using HTTP between containers simplifies test setup. Putting
+TLS client/server interop out-of-scope for these tests is acceptable, as it’s
+not of interest.)
 
-Log output SHOULD be captured into the directory “/logs” inside the container. This will be copied out to the host for inspection on completion of the test case.
+Log output SHOULD be captured into the directory “/logs” inside the container.
+This will be copied out to the host for inspection on completion of the test
+case.
 
 No environment variables or volume mounts will be provided to the containers.
 
 
 # Interoperation Test API {#test-api}
 
-Each container will have an HTTP server listening on port 8080 for commands from the test runner. All requests MUST use the HTTP method POST. Requests and responses for each endpoint listed below SHALL be encoded JSON objects {{!RFC8729}}, with media type `application/json`. All binary blobs (i.e. task IDs, batch IDs, HPKE configurations, and verification keys) SHALL be encoded as strings with base64url {{!RFC4648}}, inside the JSON objects. Any integer values in a VDAF's parameters, measurement, or aggregate result will be encoded as strings in base 10 instead of as numbers. This avoids incompatibilities due to limitations on the range of JSON numbers that different implementations can process.
+Each container will have an HTTP server listening on port 8080 for commands from
+the test runner. All requests MUST use the HTTP method POST. Requests and
+responses for each endpoint listed below SHALL be encoded JSON objects
+{{!RFC8729}}, with media type `application/json`. All binary blobs (i.e. task
+IDs, batch IDs, HPKE configurations, and verification keys) SHALL be encoded as
+strings with base64url {{!RFC4648}}, inside the JSON objects. Any integer values
+in a VDAF's parameters, measurement, or aggregate result will be encoded as
+strings in base 10 instead of as numbers. This avoids incompatibilities due to
+limitations on the range of JSON numbers that different implementations can
+process.
 
-Each of these test APIs should return a status code of 200 OK if the command was received, recognized, and parsed successfully, regardless of whether any underlying DAP-PPM request succeeded or failed. The DAP-level success or failure will be included in the test API response body. If a request is made to an endpoint starting with “/internal/test/”, but not listed here, a status code of 404 Not Found SHOULD be returned, to simplify the introduction of new test APIs.
+Each of these test APIs should return a status code of 200 OK if the command was
+received, recognized, and parsed successfully, regardless of whether any
+underlying DAP-PPM request succeeded or failed. The DAP-level success or failure
+will be included in the test API response body. If a request is made to an
+endpoint starting with “/internal/test/”, but not listed here, a status code of
+404 Not Found SHOULD be returned, to simplify the introduction of new test APIs.
 
 
 ## Common Structures
 
 ### VDAF
 
-In multiple APIs defined below, the test runner will send the name of a VDAF, along with the parameters necessary to fully specify the VDAF. These will be stored in a nested object, with the following attributes (new `type` values and new keys will be added as new VDAFs are defined).
+In multiple APIs defined below, the test runner will send the name of a VDAF,
+along with the parameters necessary to fully specify the VDAF. These will be
+stored in a nested object, with the following attributes (new `type` values and
+new keys will be added as new VDAFs are defined).
 
 |Key|Value|
 |`type`|One of `"Prio3Aes128Count"`, `"Prio3Aes128CountVec"`, `"Prio3Aes128Sum"`, or `"Prio3Aes128Histogram"`|
@@ -103,11 +161,15 @@ In multiple APIs defined below, the test runner will send the name of a VDAF, al
 
 ### Query {#query}
 
-In multiple APIs defined below, the test runner will need to send a query type, and in one API, it will need to send a query type along with the associated query parameters.
+In multiple APIs defined below, the test runner will need to send a query type,
+and in one API, it will need to send a query type along with the associated
+query parameters.
 
-Query types are represented in API requests as numbers, following the values of the `QueryType` enum in [DAP-PPM].
+Query types are represented in API requests as numbers, following the values of
+the `QueryType` enum in [DAP-PPM].
 
-Queries are represented in API requests as a nested object, with the following attributes (new keys will be added as new query types are defined).
+Queries are represented in API requests as a nested object, with the following
+attributes (new keys will be added as new query types are defined).
 
 |Key|Value|
 |`type`|A number, representing a query type, as described above.|
@@ -121,12 +183,17 @@ Queries are represented in API requests as a nested object, with the following a
 
 ### `/internal/test/ready` {#client-ready}
 
-The test runner will POST an empty object (i.e. `{}`) to this endpoint to check if the client container is ready to serve requests. If it is ready, it MUST return a status code of 200 OK.
+The test runner will POST an empty object (i.e. `{}`) to this endpoint to check
+if the client container is ready to serve requests. If it is ready, it MUST
+return a status code of 200 OK.
 
 
 ### `/internal/test/upload` {#upload}
 
-Upon receipt of this command, the client container will construct a DAP-PPM report with the given configuration and measurement, and submit it. The client container will send its response to the test runner once report submission has either succeeded or permanently failed.
+Upon receipt of this command, the client container will construct a DAP-PPM
+report with the given configuration and measurement, and submit it. The client
+container will send its response to the test runner once report submission has
+either succeeded or permanently failed.
 
 |Key|Value|
 |`task_id`|A base64url-encoded DAP-PPM `TaskId`.|
@@ -148,14 +215,26 @@ Upon receipt of this command, the client container will construct a DAP-PPM repo
 
 ### `/internal/test/ready` {#aggregator-ready}
 
-The test runner will POST an empty object (i.e. `{}`) to this endpoint to check if the aggregator container is ready to serve requests. If it is ready, it MUST return a status code of 200 OK.
+The test runner will POST an empty object (i.e. `{}`) to this endpoint to check
+if the aggregator container is ready to serve requests. If it is ready, it MUST
+return a status code of 200 OK.
 
 
 ### `/internal/test/endpoint_for_task` {#endpoint-for-task}
 
-Request the base URL for DAP-PPM endpoints for a new task. This API will be invoked immediately before `/internal/test/add_task` (see {{aggregator-add-task}}), to determine the endpoint URLs of the aggregators. If the aggregator uses a common set of DAP-PPM endpoints for all tasks, it could always return the same value, such as the relative URL `/`. Alternately, implementations may wish to generate new endpoints for each task, derive the endpoint based on the `TaskId`, etc.
+Request the base URL for DAP-PPM endpoints for a new task. This API will be
+invoked immediately before `/internal/test/add_task` (see
+{{aggregator-add-task}}), to determine the endpoint URLs of the aggregators. If
+the aggregator uses a common set of DAP-PPM endpoints for all tasks, it could
+always return the same value, such as the relative URL `/`. Alternately,
+implementations may wish to generate new endpoints for each task, derive the
+endpoint based on the `TaskId`, etc.
 
-The test runner will provide the hostname at which the aggregator is externally reachable. If the aggregator returns a relative URL, the test runner will combine it with the hostname into an absolute URL, assuming that the port is 8080. Otherwise, the aggregator can incorporate the hostname into an absolute URL and return that.
+The test runner will provide the hostname at which the aggregator is externally
+reachable. If the aggregator returns a relative URL, the test runner will
+combine it with the hostname into an absolute URL, assuming that the port is
+8080. Otherwise, the aggregator can incorporate the hostname into an absolute
+URL and return that.
 
 |Key|Value|
 |`task_id`|A base64url-encoded DAP-PPM `TaskId`|
@@ -174,7 +253,8 @@ The test runner will provide the hostname at which the aggregator is externally 
 
 Register a task with the aggregator, with the given configuration and secrets.
 
-The HPKE keypair generated for this task should use the mandatory-to-implement algorithms in section 6 of [DAP-PPM], for broad compatibility.
+The HPKE keypair generated for this task should use the mandatory-to-implement
+algorithms in section 6 of [DAP-PPM], for broad compatibility.
 
 |Key|Value|
 |`task_id`|A base64url-encoded DAP-PPM `TaskId`.|
@@ -203,7 +283,8 @@ The HPKE keypair generated for this task should use the mandatory-to-implement a
 
 ### `/internal/test/fetch_batch_ids` {#fetch-batch-ids}
 
-Retrieve the identifiers of every batch generated by the leader from a task's reports. This is only applicable to tasks with a fixed size query type.
+Retrieve the identifiers of every batch generated by the leader from a task's
+reports. This is only applicable to tasks with a fixed size query type.
 
 |Key|Value|
 |`task_id`|A base64url-encoded DAP-PPM `TaskId`.|
@@ -220,12 +301,15 @@ Retrieve the identifiers of every batch generated by the leader from a task's re
 
 ### `/internal/test/ready` {#collector-ready}
 
-The test runner will POST an empty object (i.e. `{}`) to this endpoint to check if the collector container is ready to serve requests. If it is ready, it MUST return a status code of 200 OK.
+The test runner will POST an empty object (i.e. `{}`) to this endpoint to check
+if the collector container is ready to serve requests. If it is ready, it MUST
+return a status code of 200 OK.
 
 
 ### `/internal/test/add_task` {#collector-add-task}
 
-Register a task with the collector, with the given configuration. Returns the collector’s HPKE configuration for this task.
+Register a task with the collector, with the given configuration. Returns the
+collector’s HPKE configuration for this task.
 
 |Key|Value|
 |`task_id`|A base64url-encoded DAP-PPM `TaskId`.|
@@ -244,7 +328,10 @@ Register a task with the collector, with the given configuration. Returns the co
 
 ### `/internal/test/collect_start` {#collect-start}
 
-Send a collect request to the leader with the provided parameters, and return a handle to the test runner identifying this collect request. The test runner will provide this handle to the collector in subsequent `/internal/test/collect_poll` requests (see {{collect-poll}}).
+Send a collect request to the leader with the provided parameters, and return a
+handle to the test runner identifying this collect request. The test runner will
+provide this handle to the collector in subsequent `/internal/test/collect_poll`
+requests (see {{collect-poll}}).
 
 |Key|Value|
 |`task_id`|A base64url-encoded DAP-PPM `TaskId`.|
@@ -261,7 +348,9 @@ Send a collect request to the leader with the provided parameters, and return a 
 
 ### `/internal/test/collect_poll` {#collect-poll}
 
-Upon receiving this command, the collector will poll the leader’s collect URL for the collect job associated with the provided handle, and provide the status and result to the test runner.
+Upon receiving this command, the collector will poll the leader’s collect URL
+for the collect job associated with the provided handle, and provide the status
+and result to the test runner.
 
 |Key|Value|
 |`handle`|The handle for a collect request from a previous invocation of `/internal/test/collect_start`. (see {{collect-start}})|
@@ -277,7 +366,10 @@ Upon receiving this command, the collector will poll the leader’s collect URL 
 
 ### Heavy Hitters
 
-Once Poplar1 reaches a future draft of [DAP-PPM], additional test APIs for collector containers should be introduced to perform an entire Heavy Hitters computation on a given Poplar1 task and collection interval, encompassing multiple collect flows automatically initiated by the collector.
+Once Poplar1 reaches a future draft of [DAP-PPM], additional test APIs for
+collector containers should be introduced to perform an entire Heavy Hitters
+computation on a given Poplar1 task and collection interval, encompassing
+multiple collect flows automatically initiated by the collector.
 
 
 ## Test Cases
@@ -285,43 +377,68 @@ Once Poplar1 reaches a future draft of [DAP-PPM], additional test APIs for colle
 Test cases could be written to cover the following scenarios.
 
 * Test successful aggregations with each VDAF.
-* Test an aggregation over a few hundred or thousand reports, to exercise the aggregators' division of reports into aggregation jobs.
+* Test an aggregation over a few hundred or thousand reports, to exercise the
+  aggregators' division of reports into aggregation jobs.
 * Test that uploading a report with a time far in the future is rejected.
-* Confirm that leaders and helpers reject requests with respective authentication tokens that are incorrect.
-* Test enforcement of `max_batch_lifetime` by making overlapping collect requests.
-* Perform an entire aggregation and collect flow, attempt to upload a late report that falls into the same collect interval, and test that performing the collect request a second time yields the same result.
-* Attempt to upload a canned report from the test runner more than once, and confirm that anti-replay measures were effective by inspecting the aggregation result.
+* Confirm that leaders and helpers reject requests with respective
+  authentication tokens that are incorrect.
+* Test enforcement of `max_batch_lifetime` by making overlapping collect
+  requests.
+* Perform an entire aggregation and collect flow, attempt to upload a late
+  report that falls into the same collect interval, and test that performing the
+  collect request a second time yields the same result.
+* Attempt to upload a canned report from the test runner more than once, and
+  confirm that anti-replay measures were effective by inspecting the aggregation
+  result.
 
 
 ## Other Test Considerations
 
 All test cases should automatically fail after a generous timeout.
 
-It is the responsibility of the test runner to wait for all containers to start up and respond successfully to a request to `/internal/test/ready` before sending any further commands.
+It is the responsibility of the test runner to wait for all containers to start
+up and respond successfully to a request to `/internal/test/ready` before
+sending any further commands.
 
-Aggregator URLs will be constructed by the test runner with hostnames that resolve to the respective containers within the container network.
+Aggregator URLs will be constructed by the test runner with hostnames that
+resolve to the respective containers within the container network.
 
-Once a future [DAP-PPM] draft solves the issue of retries in the aggregate flow, a reverse proxy could be introduced in front of each aggregator to inject failures when sending requests or responses, to test the protocol's resilience. (It is known such a test would fail based on the current protocol.)
+Once a future [DAP-PPM] draft solves the issue of retries in the aggregate flow,
+a reverse proxy could be introduced in front of each aggregator to inject
+failures when sending requests or responses, to test the protocol's resilience.
+(It is known such a test would fail based on the current protocol.)
 
 
 ## Test Runner Operation
 
-The following sequence outlines how the test runner will use the above APIs on port 8080 of each container to perform a typical integration test, executing a successful aggregation.
+The following sequence outlines how the test runner will use the above APIs on
+port 8080 of each container to perform a typical integration test, executing a
+successful aggregation.
 
 1. Create and start containers.
 1. Set up networking between containers.
-1. Try sending `/internal/test/ready` requests to each container, and retry until they succeed.
-1. Generate a random `TaskId`, random authentication tokens, and a VDAF verification key.
-1. Send a `/internal/test/endpoint_for_task` request ({{endpoint-for-task}}) to the leader.
+1. Try sending `/internal/test/ready` requests to each container, and retry
+   until they succeed.
+1. Generate a random `TaskId`, random authentication tokens, and a VDAF
+   verification key.
+1. Send a `/internal/test/endpoint_for_task` request ({{endpoint-for-task}}) to
+   the leader.
 1. Send a `/internal/test/endpoint_for_task` request to the helper.
 1. Construct aggregator URLs using the above responses.
-1. Send a `/internal/test/add_task` request ({{collector-add-task}}) to the collector. (the collector generates an HPKE key pair as a side-effect)
-1. Send a `/internal/test/add_task` request ({{aggregator-add-task}}) to the leader.
-1. Send a `/internal/test/add_task` request ({{aggregator-add-task}}) to the helper.
+1. Send a `/internal/test/add_task` request ({{collector-add-task}}) to the
+   collector. (the collector generates an HPKE key pair as a side-effect)
+1. Send a `/internal/test/add_task` request ({{aggregator-add-task}}) to the
+   leader.
+1. Send a `/internal/test/add_task` request ({{aggregator-add-task}}) to the
+   helper.
 1. Send one or more `/internal/test/upload` requests ({{upload}}) to the client.
-1. If the task has a fixed size query type, send a `/internal/test/fetch_batch_ids` request ({{fetch-batch-ids}}) to the leader.
-1. Send one or more `/internal/test/collect_start` requests ({{collect-start}}) to the collector. (this provides a handle for use in the next step)
-1. Send `/internal/test/collect_poll` requests ({{collect-poll}}) to the collector, polling until it is completed. (the collector will provide the calculated aggregate result)
+1. If the task has a fixed size query type, send a
+   `/internal/test/fetch_batch_ids` request ({{fetch-batch-ids}}) to the leader.
+1. Send one or more `/internal/test/collect_start` requests ({{collect-start}})
+   to the collector. (this provides a handle for use in the next step)
+1. Send `/internal/test/collect_poll` requests ({{collect-poll}}) to the
+   collector, polling until it is completed. (the collector will provide the
+   calculated aggregate result)
 1. Stop containers.
 1. Copy logs out of each container.
 1. Delete containers, and clean up container networking resources.
@@ -336,7 +453,9 @@ Additional DAP-PPM implementations would be warmly welcomed.
 
 # Security Considerations
 
-Any DAP-PPM implementation that adopts this testing interface should ensure that the test-only APIs described herein are only present in software used for testing purposes, and not in production systems.
+Any DAP-PPM implementation that adopts this testing interface should ensure that
+the test-only APIs described herein are only present in software used for
+testing purposes, and not in production systems.
 
 
 # IANA Considerations
@@ -349,4 +468,5 @@ This document has no IANA actions.
 # Acknowledgments
 {:numbered="false"}
 
-Thanks to Brandon Pitman, Christopher Patton, and Tim Geoghegan for feedback and contributions.
+Thanks to Brandon Pitman, Christopher Patton, and Tim Geoghegan for feedback and
+contributions.


### PR DESCRIPTION
This wraps most of the Markdown file at 80 characters, save for the tables (where newlines are semantically meaningful, indicating new rows) and the YAML metadata. This addresses part of #15.