### PR TITLE
Add support for Poplar1

### DIFF
--- a/draft-dcook-ppm-dap-interop-test-design.md
+++ b/draft-dcook-ppm-dap-interop-test-design.md
@@ -354,46 +354,6 @@ status and (if available) result to the test runner.
 {: title="Response JSON object structure"}
 
 
-### `/internal/test/heavy_hitters_start` {#heavy-hitters-start}
-
-Starts a series of aggregations to find the most common client inputs during a
-batch interval, and returns a handle to the test runner identifying this heavy
-hitters request. The test runner will provide this handle to the collector in
-subsequent `/internal/test/heavy_hitters_poll` requests (see
-{{heavy-hitters-poll}}). This API can only be used with Poplar1 DAP tasks.
-
-|Key|Value|
-|`task_id`|A base64url-encoded DAP `TaskId`.|
-|`count`|Determines how many of the most common inputs should be returned.|
-|`query`|An object, with the layout given in {{query-object}}. This provides the query for each underlying collect request, and in turn determines which reports should be included.|
-{: title="Request JSON object structure"}
-
-|Key|Value|
-|`status`|`"success"` if the collect request succeeded, or `"error"` otherwise.|
-|`error` (optional)|An optional error message, to assist in troubleshooting. This will be included in the test runner logs.|
-|`handle` (if successful)|A handle produced by the collector to refer to this heavy hitters request. This must be a string.|
-{: title="Response JSON object structure"}
-
-
-### `/internal/test/heavy_hitters_poll` {#heavy-hitters-poll}
-
-The test runner sends this command to a collector to poll for completion of a
-run of the heavy hitters algorithm, where the original request is identified by
-the provided handle. The collector provides the status and (if available) result
-to the test runner.
-
-|Key|Value|
-|`handle`|The handle for a heavy hitters request from a previous invocation of `/internal/test/heavy_hitters_start`. (see {{heavy-hitters-start}})|
-{: title="Request JSON object structure"}
-
-|Key|Value|
-|`status`|Either `"complete"` if the result is ready, `"in progress"` if the result is not yet ready, or `"error"` if an error occurred.|
-|`error` (optional)|An optional error message, to assist in troubleshooting. This will be included in the test runner logs.|
-|`report_count` (if complete)|A number, reflecting the count of client reports included in this result.|
-|`result` (if complete)|The result of the heavy hitters algorithm. This will be an array of objects, with length equal to the `count` parameter from the original request. Each object contains a "count" attribute, with a number value equal to the number of times an input occurred in the batch, and an "input" attribute, with a string value equal to the corresponding input, extended to a byte boundary with zero bits, and then base64url-encoded.|
-{: title="Response JSON object structure"}
-
-
 ## Test Cases
 
 Test cases could be written to cover the following scenarios.

--- a/draft-dcook-ppm-dap-interop-test-design.md
+++ b/draft-dcook-ppm-dap-interop-test-design.md
@@ -204,7 +204,7 @@ either succeeded or permanently failed.
 |`leader`|The leader's endpoint URL.|
 |`helper`|The helper's endpoint URL.|
 |`vdaf`|An object, with the layout given in {{vdaf-object}}. This determines the VDAF to be used when constructing a report.|
-|`measurement`|If the VDAF's `type` is `"Prio3Aes128Count"`: `"0"` or `"1"`. If the VDAF's `type` is `"Prio3Aes128CountVec"`: an array of strings, each of which is `"0"` or `"1"`. If the VDAF's `type` is `"Prio3Aes128Sum"`: a string (representing an integer in base 10). If the VDAF's `type` is `"Prio3Aes128Histogram"`: a string (representing an integer in base 10). If the VDAF's `type` is `"Poplar1Aes128"`: a string, equal to the input extended to a byte boundary with zero bits, and then base64url-encoded.|
+|`measurement`|If the VDAF's `type` is `"Prio3Aes128Count"`: `"0"` or `"1"`. If the VDAF's `type` is `"Prio3Aes128CountVec"`: an array of strings, each of which is `"0"` or `"1"`. If the VDAF's `type` is `"Prio3Aes128Sum"`: a string (representing an integer in base 10). If the VDAF's `type` is `"Prio3Aes128Histogram"`: a string (representing an integer in base 10). If the VDAF's `type` is `"Poplar1Aes128"`: an array of Booleans.|
 |`time` (optional)|If present, this provides a substitute time value that should be used when constructing the report. If not present, the current system time should be used, as per normal. The time is represented as a number, with a value of the number of seconds since the UNIX epoch.|
 |`time_precision`|A number, providing the precision in seconds of report timestamps.|
 {: title="Request JSON object structure"}


### PR DESCRIPTION
This makes the following changes to support Poplar1 in the test API.

- Add Poplar1Aes128 to the list of VDAF types, and specify encoding of its parameter.
- Add encoding of Poplar1 measurements.
- Add encoding of Poplar1 aggregate results.
- ~~Add a separate pair of collector APIs to do an entire end-to-end heavy hitters calculation.~~

cc @branlwyd @cjpatton @tgeoghegan